### PR TITLE
Install node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
 
 jobs:
   build-electron-secure-defaults:
+    description: Generate 
     docker:
       - image: cimg/base:stable
     steps:
@@ -12,7 +13,17 @@ jobs:
       - node/install:
           install-yarn: true
           node-version: '18.16.0'
-      - run: node --version
+      - run:
+          name: Installing Dependencies...
+          command: npm install
+      - run:
+          name: Compiling Typescript...
+          command: npm run build
+      - run:
+          name: Packaging Application...
+          command: mkdir .cache && npm run package
+      - store_artifacts:
+          path: package
 
 workflows:
   electron-secure-defaults:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@5.1.0
+
+jobs:
+  build-electron-secure-defaults:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - node/install:
+          install-yarn: true
+          node-version: '18.16.0'
+      - run: node --version
+
+workflows:
+  electron-secure-defaults:
+    jobs:
+      - build-electron-secure-defaults

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+function install_electron_builder () {
+    echo "Installing Electron Builder"
+    yarn add electron-builder
+}
+
+#---------------------------------#
+#            MAIN                 #
+#---------------------------------#
+
+install_electron_builder


### PR DESCRIPTION
## Add CircleCI Configuration File
- Use the CircleCI Node JS Orb
  https://circleci.com/developer/orbs/orb/circleci/node
- Install Latest Stable Node version: 18.16.0 LTS


## Build and Package Electron Secure Defaults
- Install dependencies using `npm install`
- Compile Typescript for to prepare for packaging
- Package the application using Electron Builder
    - The `.cache` folder is pre-created to allow for temp storage while
      the packages are being created.
- Store the finished packages as artifacts for local testing
    - Artifacts will be downloadable from the build on CircleCI